### PR TITLE
changed ping function to static

### DIFF
--- a/icmplib.h
+++ b/icmplib.h
@@ -621,7 +621,7 @@ namespace icmplib {
     using PingResult = ICMPEcho::Result;
     using PingResponseType = ICMPEcho::Result::ResponseType;
 
-    PingResult Ping(const IPAddress &target, unsigned timeout = 60, uint16_t sequence = 1, uint8_t ttl = 255) {
+    static PingResult Ping(const IPAddress &target, unsigned timeout = 60, uint16_t sequence = 1, uint8_t ttl = 255) {
         return ICMPEcho::Execute(target, timeout, sequence, ttl);
     }
 }


### PR DESCRIPTION
This fixes a linker issue when including the header in multiple files.

I encountered this issue when including the header file in a separate class as well as the main.cpp and then using the class inside of my main.cpp
This causes the following linker issue:
```
multiple definition of `icmplib::Ping(...)
```